### PR TITLE
Issue 5 update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Cargo.lock
 
 # IDE files
 .idea
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ freqfs = "0.12"
 futures = "0.3"
 get-size = "0.1"
 log = { version = "0.4", features = ["release_max_level_info"], optional = true }
-num_cpus = "1.16"
-pin-project = "1.0"
+num_cpus = "1.17"
+pin-project = "1.1"
 safecast = "0.2"
-smallvec = "1.13"
-uuid = "1.10"
+smallvec = "1.15"
+uuid = "1.23"
 
 [dev-dependencies]
 rand = "0.10"
-tokio = { version = "1.39", features = ["macros"] }
+tokio = { version = "1.51", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "b-tree"
 version = "0.4.0"
 authors = ["code@tinychain.net"]
-edition = "2021"
+edition = "2024"
 description = "A persistent B+ tree using freqfs"
 license = "Apache-2.0"
 readme = "README.md"
@@ -14,17 +14,16 @@ categories = ["database", "database-implementations", "data-structures"]
 [features]
 all = ["logging", "stream"]
 logging = ["log", "freqfs/logging"]
-stream = ["async-trait", "collate/stream", "destream", "freqfs/stream"]
+stream = ["collate/stream", "destream", "freqfs/stream"]
 
 [[example]]
 name = "example"
 required-features = ["stream"]
 
 [dependencies]
-async-trait = { version = "0.1", optional = true }
 collate = "0.4"
-destream = { version = "0.8", optional = true }
-freqfs = "0.10"
+destream = { version = "0.10.1", optional = true }
+freqfs = "0.12"
 futures = "0.3"
 get-size = "0.1"
 log = { version = "0.4", features = ["release_max_level_info"], optional = true }
@@ -35,5 +34,5 @@ smallvec = "1.13"
 uuid = "1.10"
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.10"
 tokio = { version = "1.39", features = ["macros"] }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -166,7 +166,7 @@ async fn functional_test() -> Result<(), io::Error> {
 
         {
             let range = Range::with_range(vec![], 0..67);
-            let mut keys = view.clone().keys(range, false).await?;
+            let mut keys = view.clone().keys(range).await?;
             while let Some(key) = keys.try_next().await? {
                 assert_eq!(key[0], i);
                 i += 1;
@@ -175,7 +175,7 @@ async fn functional_test() -> Result<(), io::Error> {
 
         {
             let range = Range::with_range(vec![], 67..250);
-            let mut keys = view.clone().keys(range, false).await?;
+            let mut keys = view.clone().keys(range).await?;
             while let Some(key) = keys.try_next().await? {
                 assert_eq!(key[0], i);
                 i += 1;
@@ -185,10 +185,7 @@ async fn functional_test() -> Result<(), io::Error> {
         let mut i = 1;
 
         {
-            let mut keys = view
-                .clone()
-                .keys(Range::with_range(vec![], 0..123), false)
-                .await?;
+            let mut keys = view.clone().keys(Range::with_range(vec![], 0..123)).await?;
 
             while let Some(key) = keys.try_next().await? {
                 assert_eq!(key[0], i);
@@ -197,7 +194,7 @@ async fn functional_test() -> Result<(), io::Error> {
         }
 
         {
-            let mut keys = view.keys(Range::with_range(vec![], 123..n), false).await?;
+            let mut keys = view.keys(Range::with_range(vec![], 123..n)).await?;
             while let Some(key) = keys.try_next().await? {
                 assert_eq!(key[0], i);
                 i += 1;
@@ -224,7 +221,7 @@ async fn functional_test() -> Result<(), io::Error> {
 
         {
             let mut i = n - 1;
-            let mut reversed = view.clone().keys(Range::<i16>::default(), true).await?;
+            let mut reversed = view.clone().keys_rev(Range::<i16>::default()).await?;
             while let Some(key) = reversed.try_next().await? {
                 assert_eq!(key[0], i);
                 i -= 1;
@@ -296,7 +293,7 @@ async fn functional_test() -> Result<(), io::Error> {
         #[cfg(debug_assertions)]
         assert!(view.clone().is_valid().await?);
 
-        let mut keys = view.keys(Range::<i16>::default(), false).await?;
+        let mut keys = view.keys(Range::<i16>::default()).await?;
         assert_eq!(keys.try_next().await?, None);
     }
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -2,12 +2,11 @@ use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::{fmt, io};
 
-use async_trait::async_trait;
 use collate::Collator;
 use destream::{de, en};
 use freqfs::Cache;
 use futures::{TryFutureExt, TryStreamExt};
-use rand::Rng;
+use rand::RngExt;
 use safecast::as_type;
 use smallvec::smallvec;
 use tokio::fs;
@@ -16,11 +15,11 @@ use b_tree::{BTreeLock, Node, Range, Schema};
 
 const BLOCK_SIZE: usize = 4_096;
 
+#[derive(Clone)]
 enum File {
     Node(Node<Vec<Vec<i16>>>),
 }
 
-#[async_trait]
 impl de::FromStream for File {
     type Context = ();
 
@@ -91,9 +90,9 @@ impl<T: fmt::Debug> Schema for ExampleSchema<T> {
 }
 
 async fn setup_tmp_dir() -> Result<PathBuf, io::Error> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     loop {
-        let rand: u32 = rng.gen();
+        let rand: u32 = rng.random();
         let path = PathBuf::from(format!("/tmp/test_btree_{}", rand));
         if !path.exists() {
             fs::create_dir(&path).await?;
@@ -271,7 +270,7 @@ async fn functional_test() -> Result<(), io::Error> {
             let lo = view.first(Range::<i16>::default()).await?.expect("first")[0];
             let hi = view.last(Range::<i16>::default()).await?.expect("last")[0];
 
-            let i = rand::thread_rng().gen_range(lo..(hi + 1));
+            let i = rand::rng().random_range(lo..(hi + 1));
             let key = [i, i16::MAX - i, i16::MAX - 2 * i];
 
             let present = view.contains(&key).await?;
@@ -326,23 +325,23 @@ async fn load_test() -> Result<(), io::Error> {
         assert_eq!(view.count(&Range::<i16>::default()).await?, 0);
 
         for _ in 0..(n / 2) {
-            let i: i16 = rand::thread_rng().gen_range(i16::MIN..i16::MAX);
+            let i: i16 = rand::rng().random_range(i16::MIN..i16::MAX);
             let key = vec![i, i / 2, i % 2];
             view.insert(key).await?;
         }
 
         for _ in (n / 2)..n {
-            let i: i16 = rand::thread_rng().gen_range(i16::MIN..i16::MAX);
+            let i: i16 = rand::rng().random_range(i16::MIN..i16::MAX);
             let key = vec![i, i / 2, i % 2];
             view.insert(key).await?;
 
-            let i: i16 = rand::thread_rng().gen_range(i16::MIN..i16::MAX);
+            let i: i16 = rand::rng().random_range(i16::MIN..i16::MAX);
             let key = [i, i / 2, i % 2];
             view.delete(&key).await?;
         }
 
         for _ in 0..(n / 2) {
-            let i: i16 = rand::thread_rng().gen_range(i16::MIN..i16::MAX);
+            let i: i16 = rand::rng().random_range(i16::MIN..i16::MAX);
             let key = [i, i / 2, i % 2];
             view.delete(&key).await?;
         }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -87,6 +87,10 @@ impl<T: fmt::Debug> Schema for ExampleSchema<T> {
             ))
         }
     }
+
+    fn is_empty(&self) -> bool {
+        self.size == 0
+    }
 }
 
 async fn setup_tmp_dir() -> Result<PathBuf, io::Error> {

--- a/src/group.rs
+++ b/src/group.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::io;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll, ready};
 
 use futures::stream::{Fuse, Stream, StreamExt};
 use pin_project::pin_project;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,9 @@ pub trait Schema: Eq + fmt::Debug {
     /// Get the number of columns in this [`Schema`].
     fn len(&self) -> usize;
 
+    /// Return true if this [`Schema`] is empty
+    fn is_empty(&self) -> bool;
+
     /// Get the order of the nodes in a B+Tree with this [`Schema`].
     fn order(&self) -> usize;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -47,16 +47,12 @@ impl<V: fmt::Debug> Block<V> for Vec<Vec<V>> {
             return (0, self.len());
         }
 
-        if let Some(first) = self.first() {
-            if range.overlaps_value(first, collator) == Overlap::Less {
-                return (0, 0);
-            }
+        if let Some(first) = self.first() && range.overlaps_value(first, collator) == Overlap::Less {
+            return (0, 0);
         }
 
-        if let Some(last) = self.last() {
-            if range.overlaps_value(last, collator) == Overlap::Greater {
-                return (self.len(), self.len());
-            }
+        if let Some(last) = self.last() && range.overlaps_value(last, collator) == Overlap::Greater {
+            return (self.len(), self.len());
         }
 
         // bisect range left
@@ -140,10 +136,7 @@ pub enum Node<N> {
 impl<N> Node<N> {
     /// Return `true` if this is a leaf node.
     pub fn is_leaf(&self) -> bool {
-        match self {
-            Self::Leaf(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::Leaf(_))
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -43,7 +43,7 @@ impl<V: fmt::Debug> Block<V> for Vec<Vec<V>> {
     {
         // handle common edge cases
 
-        if range.is_default() {
+        if range.is_empty() {
             return (0, self.len());
         }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -8,8 +8,8 @@ use destream::{de, en};
 use get_size::GetSize;
 use uuid::Uuid;
 
-use super::range::Range;
 use super::Collator;
+use super::range::Range;
 
 const UUID_SIZE: usize = 16;
 
@@ -47,11 +47,15 @@ impl<V: fmt::Debug> Block<V> for Vec<Vec<V>> {
             return (0, self.len());
         }
 
-        if let Some(first) = self.first() && range.overlaps_value(first, collator) == Overlap::Less {
+        if let Some(first) = self.first()
+            && range.overlaps_value(first, collator) == Overlap::Less
+        {
             return (0, 0);
         }
 
-        if let Some(last) = self.last() && range.overlaps_value(last, collator) == Overlap::Greater {
+        if let Some(last) = self.last()
+            && range.overlaps_value(last, collator) == Overlap::Greater
+        {
             return (self.len(), self.len());
         }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -2,8 +2,6 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt;
 
-#[cfg(feature = "stream")]
-use async_trait::async_trait;
 use collate::{Collate, Overlap, OverlapsValue};
 #[cfg(feature = "stream")]
 use destream::{de, en};
@@ -175,7 +173,6 @@ impl<C, N> NodeVisitor<C, N> {
 }
 
 #[cfg(feature = "stream")]
-#[async_trait]
 impl<N> de::Visitor for NodeVisitor<N::Context, N>
 where
     N: de::FromStream,
@@ -203,7 +200,6 @@ where
 }
 
 #[cfg(feature = "stream")]
-#[async_trait]
 impl<N> de::FromStream for Node<N>
 where
     N: de::FromStream,

--- a/src/range.rs
+++ b/src/range.rs
@@ -65,12 +65,19 @@ impl<V> Range<V> {
 
     /// Return `false` if this [`Range`] has only a prefix.
     pub fn has_bounds(&self) -> bool {
-        !matches!((&self.start, &self.end), (Bound::Unbounded, Bound::Unbounded))
+        !matches!(
+            (&self.start, &self.end),
+            (Bound::Unbounded, Bound::Unbounded)
+        )
     }
 
     /// Return `true` if this [`Range`] is empty.
     pub fn is_default(&self) -> bool {
-        self.prefix.is_empty() && matches!((&self.start, &self.end), (Bound::Unbounded, Bound::Unbounded))
+        self.prefix.is_empty()
+            && matches!(
+                (&self.start, &self.end),
+                (Bound::Unbounded, Bound::Unbounded)
+            )
     }
 
     /// Return `true` if this [`Range`] is empty.

--- a/src/range.rs
+++ b/src/range.rs
@@ -72,17 +72,12 @@ impl<V> Range<V> {
     }
 
     /// Return `true` if this [`Range`] is empty.
-    pub fn is_default(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.prefix.is_empty()
             && matches!(
                 (&self.start, &self.end),
                 (Bound::Unbounded, Bound::Unbounded)
             )
-    }
-
-    /// Return `true` if this [`Range`] is empty.
-    pub fn is_empty(&self) -> bool {
-        self.is_default()
     }
 
     /// Return the number of columns specified by this [`Range`].

--- a/src/range.rs
+++ b/src/range.rs
@@ -65,22 +65,17 @@ impl<V> Range<V> {
 
     /// Return `false` if this [`Range`] has only a prefix.
     pub fn has_bounds(&self) -> bool {
-        match (&self.start, &self.end) {
-            (Bound::Unbounded, Bound::Unbounded) => false,
-            _ => true,
-        }
+        !matches!((&self.start, &self.end), (Bound::Unbounded, Bound::Unbounded))
     }
 
     /// Return `true` if this [`Range`] is empty.
     pub fn is_default(&self) -> bool {
-        if self.prefix.is_empty() {
-            match (&self.start, &self.end) {
-                (Bound::Unbounded, Bound::Unbounded) => true,
-                _ => false,
-            }
-        } else {
-            false
-        }
+        self.prefix.is_empty() && matches!((&self.start, &self.end), (Bound::Unbounded, Bound::Unbounded))
+    }
+
+    /// Return `true` if this [`Range`] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.is_default()
     }
 
     /// Return the number of columns specified by this [`Range`].
@@ -188,8 +183,8 @@ impl<C: Collate> OverlapsRange<Range<C::Value>, Collator<C>> for Range<C::Value>
         }
 
         match collator.cmp_slices(&self.prefix, &other.prefix) {
-            Ordering::Less => return Overlap::Less,
-            Ordering::Greater => return Overlap::Greater,
+            Ordering::Less => Overlap::Less,
+            Ordering::Greater => Overlap::Greater,
             Ordering::Equal => match self.prefix.len().cmp(&other.prefix.len()) {
                 Ordering::Less => {
                     let value = &other.prefix[self.prefix.len()];

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -396,7 +396,7 @@ where
     {
         Box::pin(async move {
             match &*node {
-                Node::Leaf(keys) if range.is_default() => Ok(keys.len() as u64),
+                Node::Leaf(keys) if range.is_empty() => Ok(keys.len() as u64),
                 Node::Leaf(keys) => {
                     let (l, r) = keys.bisect(range, &self.collator);
 
@@ -412,7 +412,7 @@ where
                         Ok((r - l) as u64)
                     }
                 }
-                Node::Index(_bounds, children) if range.is_default() => {
+                Node::Index(_bounds, children) if range.is_empty() => {
                     stream::iter(children)
                         .then(|node_id| self.dir.as_dir().read_file(node_id))
                         .map_ok(|node| self.count_inner(range, node))
@@ -640,11 +640,7 @@ where
     Node<S::Value>: FileLoad + fmt::Debug,
 {
     /// Construct a [`Stream`] of all the keys in the given `range` of this B+Tree.
-    pub async fn keys<BV>(
-        self,
-        range: Range<BV>,
-        reverse: bool,
-    ) -> Result<Keys<S::Value>, io::Error>
+    pub async fn keys<BV>(self, range: Range<BV>) -> Result<Keys<S::Value>, io::Error>
     where
         BV: Borrow<S::Value> + Clone + Send + Sync + 'static,
     {
@@ -653,41 +649,49 @@ where
             "B+Tree is missing its root node"
         );
 
-        if reverse {
-            let nodes = nodes_reverse(self.dir, self.collator, range, ROOT).await?;
+        let nodes = nodes_forward(self.dir, self.collator, range, ROOT).await?;
 
-            let keys = nodes
-                .map_ok(|leaf| async move {
-                    let mut keys = NodeStack::with_capacity(leaf.as_ref().len());
+        let keys = nodes
+            .map_ok(move |leaf| async move {
+                let mut keys = NodeStack::with_capacity(leaf.as_ref().len());
 
-                    for key in leaf.as_ref().iter().rev() {
-                        keys.push(key.iter().cloned().collect());
-                    }
+                for key in leaf.as_ref() {
+                    keys.push(key.iter().cloned().collect())
+                }
 
-                    Ok(stream::iter(keys).map(Ok))
-                })
-                .try_buffered(num_cpus::get())
-                .try_flatten();
+                Ok(stream::iter(keys).map(Ok))
+            })
+            .try_buffered(num_cpus::get())
+            .try_flatten();
 
-            Ok(Box::pin(keys))
-        } else {
-            let nodes = nodes_forward(self.dir, self.collator, range, ROOT).await?;
+        Ok(Box::pin(keys))
+    }
 
-            let keys = nodes
-                .map_ok(|leaf| async move {
-                    let mut keys = NodeStack::with_capacity(leaf.as_ref().len());
+    pub async fn keys_rev<BV>(self, range: Range<BV>) -> Result<Keys<S::Value>, io::Error>
+    where
+        BV: Borrow<S::Value> + Clone + Send + Sync + 'static,
+    {
+        debug_assert!(
+            self.dir.as_dir().contains(&ROOT),
+            "B+Tree is missing its root node"
+        );
 
-                    for key in leaf.as_ref() {
-                        keys.push(key.iter().cloned().collect());
-                    }
+        let nodes = nodes_reverse(self.dir, self.collator, range, ROOT).await?;
 
-                    Ok(stream::iter(keys).map(Ok))
-                })
-                .try_buffered(num_cpus::get())
-                .try_flatten();
+        let keys = nodes
+            .map_ok(|leaf| async move {
+                let mut keys = NodeStack::with_capacity(leaf.as_ref().len());
 
-            Ok(Box::pin(keys))
-        }
+                for key in leaf.as_ref().iter().rev() {
+                    keys.push(key.iter().cloned().collect());
+                }
+
+                Ok(stream::iter(keys).map(Ok))
+            })
+            .try_buffered(num_cpus::get())
+            .try_flatten();
+
+        Ok(Box::pin(keys))
     }
 
     /// Construct a [`Stream`] of unique length-`n` prefixes within the given `range`.
@@ -761,7 +765,7 @@ where
         let default_range = Range::<S::Value>::default();
         let count = self.count(&default_range).await? as usize;
         let mut contents = Vec::with_capacity(count);
-        let mut stream = self.keys(default_range, false).await?;
+        let mut stream = self.keys(default_range).await?;
         while let Some(key) = stream.try_next().await? {
             contents.push(key);
         }
@@ -810,7 +814,7 @@ where
     let file = dir.as_dir().get_file(&node_id).expect("node").clone();
     let fut = file.into_read().map_ok(move |node| {
         let read = match &*node {
-            Node::Leaf(keys) if range.is_default() => NodeRead::Leaf((0, keys.len())),
+            Node::Leaf(keys) if range.is_empty() => NodeRead::Leaf((0, keys.len())),
             Node::Leaf(keys) => {
                 let (l, r) = keys.bisect(&range, &collator);
 
@@ -826,7 +830,7 @@ where
                     NodeRead::Leaf((l, r))
                 }
             }
-            Node::Index(_bounds, children) if range.is_default() => {
+            Node::Index(_bounds, children) if range.is_empty() => {
                 debug_assert!(!children.is_empty());
 
                 if children.len() == 1 {
@@ -914,7 +918,7 @@ where
     let file = dir.as_dir().get_file(&node_id).expect("node").clone();
     let fut = file.into_read().map_ok(move |node| {
         let read = match &*node {
-            Node::Leaf(keys) if range.is_default() => NodeRead::Leaf((0, keys.len())),
+            Node::Leaf(keys) if range.is_empty() => NodeRead::Leaf((0, keys.len())),
             Node::Leaf(keys) => {
                 let (l, r) = keys.bisect(&range, &collator);
 
@@ -930,7 +934,7 @@ where
                     NodeRead::Leaf((l, r))
                 }
             }
-            Node::Index(_bounds, children) if range.is_default() => {
+            Node::Index(_bounds, children) if range.is_empty() => {
                 debug_assert!(!children.is_empty());
 
                 if children.len() == 1 {
@@ -1666,7 +1670,7 @@ where
         validate_collator_eq(&self.collator, &other.collator)?;
         validate_schema_eq(&self.schema, &other.schema)?;
 
-        let mut keys = other.keys(Range::<S::Value>::default(), false).await?;
+        let mut keys = other.keys(Range::<S::Value>::default()).await?;
         while let Some(key) = keys.try_next().await? {
             self.insert_root(key.into_vec()).await?;
         }
@@ -1684,7 +1688,7 @@ where
         validate_collator_eq(&self.collator, &other.collator)?;
         validate_schema_eq(&self.schema, &other.schema)?;
 
-        let mut keys = other.keys(Range::<S::Value>::default(), false).await?;
+        let mut keys = other.keys(Range::<S::Value>::default()).await?;
         while let Some(key) = keys.try_next().await? {
             self.delete(&key).await?;
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,27 +1,20 @@
 use std::borrow::Borrow;
+use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::{fmt, io};
-use std::mem;
 
 use collate::{Collate, OverlapsValue};
 #[cfg(feature = "stream")]
 use destream::de;
 use freqfs::{
-    DirReadGuardOwned, 
-    DirWriteGuardOwned,
-    FileReadGuardOwned,
-    FileWriteGuardOwned,
-    DirLock,
-    FileLoad,
-    FileSave,
-    DirDeref,
-    FileReadGuard,
+    DirDeref, DirLock, DirReadGuardOwned, DirWriteGuardOwned, FileLoad, FileReadGuard,
+    FileReadGuardOwned, FileSave, FileWriteGuardOwned,
 };
+use futures::TryFutureExt;
 use futures::future::{self, Future, FutureExt};
 use futures::stream::{self, Stream, StreamExt, TryStreamExt};
 use futures::try_join;
-use futures::TryFutureExt;
 use safecast::AsType;
 use smallvec::SmallVec;
 use uuid::Uuid;
@@ -29,7 +22,7 @@ use uuid::Uuid;
 use super::group::GroupBy;
 use super::node::Block;
 use super::range::Range;
-use super::{Collator, Key, Schema, NODE_STACK_SIZE};
+use super::{Collator, Key, NODE_STACK_SIZE, Schema};
 
 type NodeStack<V> = SmallVec<[Key<V>; NODE_STACK_SIZE]>;
 
@@ -484,7 +477,9 @@ where
 
         let mut node = self.dir.as_dir().read_file(&ROOT).await?;
 
-        if let Node::Leaf(keys) = &*node && keys.is_empty() {
+        if let Node::Leaf(keys) = &*node
+            && keys.is_empty()
+        {
             return Ok(None);
         }
 
@@ -532,7 +527,9 @@ where
 
         let mut node = self.dir.as_dir().read_file(&ROOT).await?;
 
-        if let Node::Leaf(keys) = &*node && keys.is_empty() {
+        if let Node::Leaf(keys) = &*node
+            && keys.is_empty()
+        {
             return Ok(None);
         }
 
@@ -1248,8 +1245,7 @@ where
         left_bounds: &'a mut Vec<Vec<S::Value>>,
         left_children: &'a mut Vec<Uuid>,
         node_id: &'a Uuid,
-    ) -> Pin<Box<dyn Future<Output = ResultMergeIndex<S::Value>> + Send + 'a>>
-    {
+    ) -> Pin<Box<dyn Future<Output = ResultMergeIndex<S::Value>> + Send + 'a>> {
         Box::pin(async move {
             let mut node = self.dir.write_file(node_id).await?;
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::{fmt, io};
+use std::mem;
 
 use collate::{Collate, OverlapsValue};
 #[cfg(feature = "stream")]
@@ -44,6 +45,16 @@ pub type Keys<V> = Pin<Box<dyn Stream<Item = Result<Key<V>, io::Error>> + Send>>
 type Nodes<FE, V> = Pin<Box<dyn Stream<Item = Result<Leaf<FE, V>, io::Error>> + Send>>;
 
 type Node<V> = super::node::Node<Vec<Vec<V>>>;
+
+type ResultNodes<FE, V> = Result<Nodes<FE, V>, io::Error>;
+
+type ResultDelete<FE, V> = Result<Delete<FE, V>, io::Error>;
+
+type ResultMergeIndex<V> = Result<MergeIndexLeft<V>, io::Error>;
+
+type ResultMergeLeaf<V> = Result<MergeLeafLeft<V>, io::Error>;
+
+type ResultInsert<V> = Result<Insert<V>, io::Error>;
 
 const ROOT: Uuid = Uuid::from_fields(0, 0, 0, &[0u8; 8]);
 
@@ -345,7 +356,7 @@ where
         loop {
             match &*node {
                 Node::Leaf(keys) => {
-                    let i = keys.bisect_left(&key, &self.collator);
+                    let i = keys.bisect_left(key, &self.collator);
 
                     break Ok(if i < keys.len() {
                         match keys.get(i) {
@@ -394,7 +405,7 @@ where
             match &*node {
                 Node::Leaf(keys) if range.is_default() => Ok(keys.len() as u64),
                 Node::Leaf(keys) => {
-                    let (l, r) = keys.bisect(&range, &self.collator);
+                    let (l, r) = keys.bisect(range, &self.collator);
 
                     if l == keys.len() {
                         Ok(0)
@@ -417,7 +428,7 @@ where
                         .await
                 }
                 Node::Index(bounds, children) => {
-                    let (l, r) = bounds.bisect(&range, &self.collator);
+                    let (l, r) = bounds.bisect(range, &self.collator);
                     let l = if l == 0 { l } else { l - 1 };
 
                     if l == children.len() {
@@ -473,10 +484,8 @@ where
 
         let mut node = self.dir.as_dir().read_file(&ROOT).await?;
 
-        if let Node::Leaf(keys) = &*node {
-            if keys.is_empty() {
-                return Ok(None);
-            }
+        if let Node::Leaf(keys) = &*node && keys.is_empty() {
+            return Ok(None);
         }
 
         Ok(loop {
@@ -523,10 +532,8 @@ where
 
         let mut node = self.dir.as_dir().read_file(&ROOT).await?;
 
-        if let Node::Leaf(keys) = &*node {
-            if keys.is_empty() {
-                return Ok(None);
-            }
+        if let Node::Leaf(keys) = &*node && keys.is_empty() {
+            return Ok(None);
         }
 
         Ok(loop {
@@ -599,7 +606,7 @@ where
         Box::pin(async move {
             let order = self.schema.order();
 
-            match &*node {
+            match node {
                 Node::Leaf(keys) => {
                     assert!(keys.len() >= (order / 2) - 1);
                     assert!(keys.len() < order);
@@ -656,8 +663,8 @@ where
                 .map_ok(|leaf| async move {
                     let mut keys = NodeStack::with_capacity(leaf.as_ref().len());
 
-                    for key in leaf.as_ref().into_iter().rev() {
-                        keys.push(key.into_iter().cloned().collect());
+                    for key in leaf.as_ref().iter().rev() {
+                        keys.push(key.iter().cloned().collect());
                     }
 
                     Ok(stream::iter(keys).map(Ok))
@@ -674,7 +681,7 @@ where
                     let mut keys = NodeStack::with_capacity(leaf.as_ref().len());
 
                     for key in leaf.as_ref() {
-                        keys.push(key.into_iter().cloned().collect());
+                        keys.push(key.iter().cloned().collect());
                     }
 
                     Ok(stream::iter(keys).map(Ok))
@@ -771,7 +778,7 @@ where
 enum NodeRead {
     Excluded,
     Child(Uuid),
-    Children(SmallVec<[Uuid; NODE_STACK_SIZE]>),
+    Children(Box<SmallVec<[Uuid; NODE_STACK_SIZE]>>),
     Leaf((usize, usize)),
 }
 
@@ -780,7 +787,7 @@ impl fmt::Debug for NodeRead {
         match self {
             Self::Excluded => f.write_str("(none)"),
             Self::Child(id) => write!(f, "child {id}"),
-            Self::Children(ids) => write!(f, "children {ids:?}"),
+            Self::Children(ids) => write!(f, "children {:?}", *ids),
             Self::Leaf((start, end)) => write!(f, "leaf records [{start}..{end})"),
         }
     }
@@ -791,7 +798,7 @@ fn nodes_forward<C, V, BV, FE, G>(
     collator: Collator<C>,
     range: Range<BV>,
     node_id: Uuid,
-) -> Pin<Box<dyn Future<Output = Result<Nodes<FE, V>, io::Error>> + Send>>
+) -> Pin<Box<dyn Future<Output = ResultNodes<FE, V>> + Send>>
 where
     C: Collate<Value = V> + Clone + Send + Sync + 'static,
     V: Clone + PartialEq + fmt::Debug + Send + Sync + 'static,
@@ -828,7 +835,7 @@ where
                 if children.len() == 1 {
                     NodeRead::Child(children[0])
                 } else {
-                    NodeRead::Children(SmallVec::from_slice(&children))
+                    NodeRead::Children(Box::new(SmallVec::from_slice(children)))
                 }
             }
             Node::Index(bounds, children) => {
@@ -842,7 +849,7 @@ where
                 } else if l == r || l + 1 == r {
                     NodeRead::Child(children[l])
                 } else {
-                    NodeRead::Children(SmallVec::from_slice(&children[l..r]))
+                    NodeRead::Children(Box::new(SmallVec::from_slice(&children[l..r])))
                 }
             }
         };
@@ -898,7 +905,7 @@ fn nodes_reverse<C, V, BV, FE, G>(
     collator: Collator<C>,
     range: Range<BV>,
     node_id: Uuid,
-) -> Pin<Box<dyn Future<Output = Result<Nodes<FE, V>, io::Error>> + Send>>
+) -> Pin<Box<dyn Future<Output = ResultNodes<FE, V>> + Send>>
 where
     C: Collate<Value = V> + Clone + Send + Sync + 'static,
     V: Clone + PartialEq + fmt::Debug + Send + Sync + 'static,
@@ -932,7 +939,7 @@ where
                 if children.len() == 1 {
                     NodeRead::Child(children[0])
                 } else {
-                    NodeRead::Children(SmallVec::from_slice(&children))
+                    NodeRead::Children(Box::new(SmallVec::from_slice(children)))
                 }
             }
             Node::Index(bounds, children) => {
@@ -948,7 +955,7 @@ where
                 } else if l == r || l + 1 == r {
                     NodeRead::Child(children[l])
                 } else {
-                    NodeRead::Children(SmallVec::from_slice(&children[l..r]))
+                    NodeRead::Children(Box::new(SmallVec::from_slice(&children[l..r])))
                 }
             }
         };
@@ -1059,7 +1066,7 @@ where
 
         let new_root = match &mut *root {
             Node::Leaf(keys) => {
-                let i = keys.bisect_left(&key, &self.collator);
+                let i = keys.bisect_left(key, &self.collator);
                 if i < keys.len() && keys[i].iter().zip(key).all(|(l, r)| l == r.borrow()) {
                     keys.remove(i);
                     return Ok(true);
@@ -1068,13 +1075,13 @@ where
                 }
             }
             Node::Index(bounds, children) => {
-                let i = match bounds.bisect_right(&key, &self.collator) {
+                let i = match bounds.bisect_right(key, &self.collator) {
                     0 => return Ok(false),
                     i => i - 1,
                 };
 
                 let node = self.dir.write_file_owned(&children[i]).await?;
-                match self.delete_inner(node, &key).await? {
+                match self.delete_inner(node, key).await? {
                     Delete::None => return Ok(false),
                     Delete::Right => return Ok(true),
                     Delete::Left(bound) => {
@@ -1105,9 +1112,9 @@ where
             let new_root = {
                 let mut child = self.dir.write_file(&only_child).await?;
                 match &mut *child {
-                    Node::Leaf(keys) => Node::Leaf(keys.drain(..).collect()),
+                    Node::Leaf(keys) => Node::Leaf(mem::take(keys)),
                     Node::Index(bounds, children) => {
-                        Node::Index(bounds.drain(..).collect(), children.drain(..).collect())
+                        Node::Index(mem::take(bounds), mem::take(children))
                     }
                 }
             };
@@ -1124,14 +1131,14 @@ where
         &'a mut self,
         mut node: FileWriteGuardOwned<FE, Node<S::Value>>,
         key: &'a [V],
-    ) -> Pin<Box<dyn Future<Output = Result<Delete<FE, S::Value>, io::Error>> + Send + 'a>>
+    ) -> Pin<Box<dyn Future<Output = ResultDelete<FE, S::Value>> + Send + 'a>>
     where
         V: Borrow<S::Value> + Send + Sync,
     {
         Box::pin(async move {
             match &mut *node {
                 Node::Leaf(keys) => {
-                    let i = keys.bisect_left(&key, &self.collator);
+                    let i = keys.bisect_left(key, &self.collator);
 
                     if i < keys.len() && keys[i].iter().zip(key).all(|(l, r)| l == r.borrow()) {
                         keys.remove(i);
@@ -1241,7 +1248,7 @@ where
         left_bounds: &'a mut Vec<Vec<S::Value>>,
         left_children: &'a mut Vec<Uuid>,
         node_id: &'a Uuid,
-    ) -> Pin<Box<dyn Future<Output = Result<MergeIndexLeft<S::Value>, io::Error>> + Send + 'a>>
+    ) -> Pin<Box<dyn Future<Output = ResultMergeIndex<S::Value>> + Send + 'a>>
     {
         Box::pin(async move {
             let mut node = self.dir.write_file(node_id).await?;
@@ -1257,14 +1264,14 @@ where
                         let mut new_bounds =
                             Vec::with_capacity(left_bounds.len() + right_bounds.len());
 
-                        new_bounds.extend(left_bounds.drain(..));
-                        new_bounds.extend(right_bounds.drain(..));
+                        new_bounds.append(left_bounds);
+                        new_bounds.append(right_bounds);
                         *right_bounds = new_bounds;
 
                         let mut new_children = Vec::with_capacity(right_bounds.len());
 
-                        new_children.extend(left_children.drain(..));
-                        new_children.extend(right_children.drain(..));
+                        new_children.append(left_children);
+                        new_children.append(right_children);
                         *right_children = new_children;
 
                         Ok(MergeIndexLeft::Merge(right_bounds[0].to_vec()))
@@ -1295,8 +1302,8 @@ where
 
                         Ok(MergeIndexRight::Borrow)
                     } else {
-                        left_bounds.extend(right_bounds.drain(..));
-                        left_children.extend(right_children.drain(..));
+                        left_bounds.append(right_bounds);
+                        left_children.append(right_children);
                         Ok(MergeIndexRight::Merge)
                     }
                 }
@@ -1346,7 +1353,7 @@ where
         &'a self,
         left_keys: &'a mut Vec<Vec<S::Value>>,
         node_id: &'a Uuid,
-    ) -> Pin<Box<dyn Future<Output = Result<MergeLeafLeft<S::Value>, io::Error>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = ResultMergeLeaf<S::Value>> + Send + 'a>> {
         Box::pin(async move {
             let mut node = self.dir.write_file(node_id).await?;
 
@@ -1357,8 +1364,8 @@ where
                         Ok(MergeLeafLeft::Borrow(right_keys[0].to_vec()))
                     } else {
                         let mut new_keys = Vec::with_capacity(left_keys.len() + right_keys.len());
-                        new_keys.extend(left_keys.drain(..));
-                        new_keys.extend(right_keys.drain(..));
+                        new_keys.append(left_keys);
+                        new_keys.append(right_keys);
                         *right_keys = new_keys;
 
                         Ok(MergeLeafLeft::Merge(right_keys[0].to_vec()))
@@ -1395,7 +1402,7 @@ where
                         right_keys.insert(0, right);
                         Ok(MergeLeafRight::Borrow)
                     } else {
-                        left_keys.extend(right_keys.drain(..));
+                        left_keys.append(right_keys);
                         Ok(MergeLeafRight::Merge)
                     }
                 }
@@ -1438,7 +1445,7 @@ where
                     let right_key = right[0].clone();
                     let (right, _) = self.dir.create_file_unique(Node::Leaf(right), size)?;
 
-                    let left: Vec<_> = keys.drain(..).collect();
+                    let left: Vec<_> = mem::take(keys);
                     debug_assert!(left.len() >= mid);
 
                     let left_key = left[0].clone();
@@ -1489,8 +1496,8 @@ where
                         .dir
                         .create_file_unique(Node::Index(right_bounds, right_children), size)?;
 
-                    let left_bounds: Vec<_> = bounds.drain(..).collect();
-                    let left_children: Vec<_> = children.drain(..).collect();
+                    let left_bounds: Vec<_> = mem::take(bounds);
+                    let left_children: Vec<_> = mem::take(children);
                     let left_bound = left_bounds[0].clone();
                     let (left_node_id, _) = self
                         .dir
@@ -1517,7 +1524,7 @@ where
         &'a mut self,
         node: &'a mut Node<S::Value>,
         key: Vec<S::Value>,
-    ) -> Pin<Box<dyn Future<Output = Result<Insert<S::Value>, io::Error>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = ResultInsert<S::Value>> + Send + 'a>> {
         Box::pin(async move {
             let order = self.schema.order();
 
@@ -1714,8 +1721,7 @@ where
         Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "B+Tree to merge must have the same collation",
-        )
-        .into())
+        ))
     }
 }
 
@@ -1733,8 +1739,7 @@ where
                 "cannot merge a B+Tree with schema {:?} into one with schema {:?}",
                 that, this
             ),
-        )
-        .into())
+        ))
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,12 +3,20 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::{fmt, io};
 
-#[cfg(feature = "stream")]
-use async_trait::async_trait;
 use collate::{Collate, OverlapsValue};
 #[cfg(feature = "stream")]
 use destream::de;
-use freqfs::*;
+use freqfs::{
+    DirReadGuardOwned, 
+    DirWriteGuardOwned,
+    FileReadGuardOwned,
+    FileWriteGuardOwned,
+    DirLock,
+    FileLoad,
+    FileSave,
+    DirDeref,
+    FileReadGuard,
+};
 use futures::future::{self, Future, FutureExt};
 use futures::stream::{self, Stream, StreamExt, TryStreamExt};
 use futures::try_join;
@@ -141,7 +149,7 @@ where
     /// Write any modified blocks of thie [`BTree`] to the filesystem.
     pub async fn sync(&self) -> Result<(), io::Error>
     where
-        FE: for<'a> freqfs::FileSave<'a>,
+        FE: FileSave + Clone,
     {
         self.dir.sync().await
     }
@@ -239,7 +247,6 @@ struct BTreeVisitor<S, C, FE> {
 }
 
 #[cfg(feature = "stream")]
-#[async_trait]
 impl<S, C, FE> de::Visitor for BTreeVisitor<S, C, FE>
 where
     S: Schema + Send + Sync,
@@ -266,7 +273,6 @@ where
 }
 
 #[cfg(feature = "stream")]
-#[async_trait]
 impl<S, C, FE> de::FromStream for BTreeLock<S, C, FE>
 where
     S: Schema + Send + Sync,


### PR DESCRIPTION
**Migration plan that was applied:**
1. Audit dependencies for known vulnerabilities via cargo audit
2. Analyze code for test coverage
3. Update rust edition and dependencies at the same time. 
4. Fix build for the crate and for the examples
5. Audit again for possible vulnerabilities introduced during dependencies update
6. Run formatter?
7. Run linter?

**Notes:**
- Update of edition and dependencies at the same time is required, because of a fact that dependencies like async-trait macroses are must be applied in dependencies traits and in it implementation for structs in a parent crate, so update dependencies without updating edition is impossible and vice versa.
- Formatter(rustfmt) and Linter(clippy) are under the question, considering that it's usage has not been discussed yet. Default usage vs custom configs?
- Clippy showed 36 suggestions during default run
- Formatter showed only 3-4 points for changes, mostly related to import of names via usage
- Audit showed only few dependencies that are not maintained anymore.

**Questions:**
- Do we plan on using a formatter, is it okay to use rustfmt? Do we want to configure it?
- Do we plan on using a linter, is it okay to use clippy? Do we want to configure it?
- What criteria for audit should be applied. What to be fixed and what to be left alone?

**Changes:**
- Adds vscode directory to gitignore
- Updates Rust edition from 2021 to 2024 to add native async support
- Removes async-trait and it's dependency
- Updates normat dependencies like destream and freqfs to latest available version
- Updates dev-dependency like rand to latest available version

